### PR TITLE
Fix: Maven project name

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -100,9 +100,9 @@ mavenPublishing {
 
     pom {
 
-        name.set(project.name)
+        name.set(rootProject.name)
         description.set("A Compose Multiplatform library providing customizable Squircle shapes for UI components.")
-        inceptionYear.set("2023-2025")
+        inceptionYear.set("2023-2026")
         url.set("https://github.com/stoyan-vuchev/squircle-shape")
 
         licenses {


### PR DESCRIPTION
maven pom.xml project.name is 'library', rename to 'SquircleShape' 

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
<!--  This module was also published with a richer model, Gradle metadata,   -->
<!--  which should be used instead. Do not delete the following line which   -->
<!--  is to indicate to Gradle or any Gradle module metadata file consumer   -->
<!--  that they should prefer consuming it instead.  -->
<!--  do_not_remove: published-with-gradle-metadata  -->
<modelVersion>4.0.0</modelVersion>
<groupId>com.stoyanvuchev</groupId>
<artifactId>squircle-shape</artifactId>
<version>5.0.0</version>
<name>library</name> <!--  module name, fix it -->
<!--  ... -->
<project>
```

ref: https://repo1.maven.org/maven2/com/stoyanvuchev/squircle-shape/5.0.0/squircle-shape-5.0.0.pom