### PR TITLE
Update: Bump version to 5.1.1 and update documentation for release channels.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,161 +10,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="07a63061-e1ac-4350-bf7c-a0f9e12acac5" name="Changes" comment="Refactor: Improve shape drawing and update dependencies.&#10;&#10;This commit introduces several key changes:&#10;&#10;-   **Refactored `SquircleShapePath`:**&#10;    -   Removed the corner radius scaling that was dependent on the smoothing value.&#10;    -   Replaced straight `lineTo` calls with `cubicTo` for the shape's edges, allowing for a subtle pinch effect and a more organic appearance.&#10;&#10;-   **Updated Dependencies:**&#10;    -   Bumped Kotlin to `2.3.0` and Compose to `1.11.0`.&#10;    -   Migrated project dependencies to use the version catalog (`libs.versions.toml`).&#10;    -   Updated the library version to `5.0.0` and changed the `groupId`.&#10;&#10;-   **Sample App Improvements:**&#10;    -   Refactored the preview screen to use a `ViewModel` for state management.&#10;    -   Introduced Koin for dependency injection.&#10;    -   Improved layout responsiveness for larger screens.&#10;&#10;-   **Documentation:**&#10;    -   Updated `README.md` with breaking changes for version `5.0.0`, new minimum requirements, and updated dependency instructions.">
-      <change afterPath="$PROJECT_DIR$/androidApp/.gitignore" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/build.gradle.kts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/consumer-rules.pro" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/proguard-rules.pro" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/src/androidTest/kotlin/com/stoyanvuchev/squircleshape/demo/ExampleInstrumentedTest.kt" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/src/main/AndroidManifest.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/androidApp/src/test/kotlin/com/stoyanvuchev/squircleshape/demo/ExampleUnitTest.kt" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/reports/problems/problems-report.html" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/.yarn-integrity" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/CHANGELOG.md" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/CheatSheet.md" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/LICENSE" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/README.md" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/bower.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.d.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.esm.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.flow.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.js.map" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/dist/js-joda.min.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Clock.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/DayOfWeek.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Duration.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Enum.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Instant.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/LocalDate.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/LocalDateTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/LocalTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/MathUtil.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Month.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/MonthDay.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/OffsetDateTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/OffsetTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Period.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/StringUtil.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/Year.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/YearConstants.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/YearMonth.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/ZoneId.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/ZoneIdFactory.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/ZoneOffset.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/ZoneRegion.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/ZonedDateTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/_init.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/assert.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/chrono/ChronoLocalDate.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/chrono/ChronoLocalDateTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/chrono/ChronoZonedDateTime.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/chrono/IsoChronology.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/convert.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/errors.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DateTimeBuilder.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DateTimeFormatter.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DateTimeFormatterBuilder.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DateTimeParseContext.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DateTimePrintContext.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/DecimalStyle.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/EnumMap.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/ParsePosition.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/ResolverStyle.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/SignStyle.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/StringBuilder.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/TextStyle.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/CharLiteralPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/CompositePrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/FractionPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/NumberPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/OffsetIdPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/PadPrinterParserDecorator.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/SettingsParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/StringLiteralPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/format/parser/ZoneIdPrinterParser.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/js-joda.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/license-preamble.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/ChronoField.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/ChronoUnit.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/DefaultInterfaceTemporal.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/IsoFields.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/NativeJsTemporal.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/Temporal.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalAccessor.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalAdjuster.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalAdjusters.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalAmount.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalField.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalQueries.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalQueriesFactory.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalQuery.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/TemporalUnit.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/temporal/ValueRange.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/use.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/zone/SystemDefaultZoneId.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/zone/SystemDefaultZoneRules.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/zone/ZoneOffsetTransition.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/zone/ZoneRules.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/node_modules/@js-joda/core/src/zone/ZoneRulesProvider.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShape-library-test/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShape-library/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp-test/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/META-INF/MANIFEST.MF" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/SquircleShapeApp.mjs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/SquircleShapeApp.uninstantiated.mjs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/SquircleShapeApp.wasm" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/SquircleShapeApp.wasm.map" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/index.html" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/js-reexport-symbols.mjs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/skiko.mjs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/skiko.wasm" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/skikod8.mjs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/kotlin/styles.css" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages/SquircleShapeApp/webpack.config.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages_imported/.visited-gradle" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/packages_imported/Kotlin-DateTime-library-kotlinx-datetime-wasm-js/0.7.1/package.json" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build/wasm/yarn.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/caches/deviceStreaming.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/caches/deviceStreaming.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/deploymentTargetSelector.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/deploymentTargetSelector.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/markdown.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/markdown.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/LICENSE" beforeDir="false" afterPath="$PROJECT_DIR$/LICENSE" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle.kts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/composeApp/build.gradle.kts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/AndroidManifest.xml" beforeDir="false" afterPath="$PROJECT_DIR$/composeApp/src/androidMain/AndroidManifest.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/kotlin/com/stoyanvuchev/squircleshape/app/MainActivity.kt" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/kotlin/com/stoyanvuchev/squircleshape/demo/MainActivity.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/drawable-v24/ic_launcher_foreground.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/drawable-v24/ic_launcher_foreground.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/drawable/ic_launcher_background.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/drawable/ic_launcher_background.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-anydpi-v26/ic_launcher.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-anydpi-v26/ic_launcher_round.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-hdpi/ic_launcher.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-hdpi/ic_launcher.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-hdpi/ic_launcher_round.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-hdpi/ic_launcher_round.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-mdpi/ic_launcher.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-mdpi/ic_launcher.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-mdpi/ic_launcher_round.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-mdpi/ic_launcher_round.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xhdpi/ic_launcher.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xhdpi/ic_launcher.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xhdpi/ic_launcher_round.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xhdpi/ic_launcher_round.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xxhdpi/ic_launcher.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xxhdpi/ic_launcher.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xxhdpi/ic_launcher_round.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xxhdpi/ic_launcher_round.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xxxhdpi/ic_launcher.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/mipmap-xxxhdpi/ic_launcher_round.webp" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher_round.webp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/values-night/themes.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/values-night/themes.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/values/strings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/values/strings.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/values/themes.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/values/themes.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/xml/backup_rules.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/xml/backup_rules.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/androidMain/res/xml/data_extraction_rules.xml" beforeDir="false" afterPath="$PROJECT_DIR$/androidApp/src/main/res/xml/data_extraction_rules.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/composeApp/src/commonMain/kotlin/App.kt" beforeDir="false" afterPath="$PROJECT_DIR$/composeApp/src/commonMain/kotlin/App.kt" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/gradle/libs.versions.toml" beforeDir="false" afterPath="$PROJECT_DIR$/gradle/libs.versions.toml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties" beforeDir="false" afterPath="$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/gradlew" beforeDir="false" afterPath="$PROJECT_DIR$/gradlew" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/iosApp/iosApp.xcodeproj/xcuserdata/stoyan.xcuserdatad/xcschemes/iosApp.xcscheme" beforeDir="false" afterPath="$PROJECT_DIR$/iosApp/iosApp.xcodeproj/xcuserdata/stoyan.xcuserdatad/xcschemes/iosApp.xcscheme" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/library/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/library/build.gradle.kts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/settings.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/settings.gradle.kts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -224,7 +73,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="master" />
+        <entry key="$PROJECT_DIR$" value="stable" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -340,7 +189,7 @@
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
     "dart.analysis.tool.window.visible": "false",
-    "git-widget-placeholder": "5.1.0/gradle9-migration",
+    "git-widget-placeholder": "release-5.1.1",
     "iOS Application.iosApp.executor": "Run",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
@@ -374,7 +223,7 @@
       <recent name="com.stoyanvuchev.squircleshape" />
     </key>
   </component>
-  <component name="RunManager" selected="Android App.androidApp">
+  <component name="RunManager" selected="Gradle.composeApp [desktop]">
     <configuration name="androidApp" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
       <module name="SquircleShape.androidApp" />
       <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />
@@ -447,7 +296,13 @@
         <option name="Android.Gradle.BeforeRunTask" enabled="true" />
       </method>
     </configuration>
-    <configuration name="iosApp" type="AppleRunConfiguration" factoryName="Application" activateToolWindowBeforeRun="false" nameIsGenerated="true" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/iosApp" PASS_PARENT_ENVS_2="true" PROJECT_NAME="iosApp" TARGET_NAME="iosApp" CONFIG_NAME="Debug" IS_LOCATION_SIMULATION_SUPPORTED="true" SCHEME_NAME="iosApp" IS_LOCATION_SIMULATION_ALLOWED="true" LOCATION_SCENARIO_ID="com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier" LOCATION_SCENARIO_TYPE="1" APPLICATION_LANGUAGE="IDELaunchSchemeLanguageUseSystemLanguage" APPLICATION_REGION="" DEVELOPMENT_TEAM="${TEAM_ID}" RUN_TARGET_PROJECT_NAME="iosApp" RUN_TARGET_NAME="iosApp" MAKE_ACTIVE="TRUE" SHOULD_DEBUG_EXTENSIONS="false">
+    <configuration default="true" type="AppleRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" IS_LOCATION_SIMULATION_SUPPORTED="false" IS_LOCATION_SIMULATION_ALLOWED="true" APPLICATION_LANGUAGE="IDELaunchSchemeLanguageUseSystemLanguage" APPLICATION_REGION="" DEVELOPMENT_TEAM="${TEAM_ID}" MAKE_ACTIVE="TRUE" SHOULD_DEBUG_EXTENSIONS="false">
+      <embedded_app_extension_list />
+      <method v="2">
+        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="iosApp" type="AppleRunConfiguration" factoryName="Application" activateToolWindowBeforeRun="false" nameIsGenerated="true" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/iosApp" PASS_PARENT_ENVS_2="true" PROJECT_NAME="iosApp" TARGET_NAME="iosApp" CONFIG_NAME="Debug" IS_LOCATION_SIMULATION_SUPPORTED="true" SCHEME_NAME="iosApp" IS_LOCATION_SIMULATION_ALLOWED="true" LOCATION_SCENARIO_ID="com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier" LOCATION_SCENARIO_TYPE="1" APPLICATION_LANGUAGE="IDELaunchSchemeLanguageUseSystemLanguage" APPLICATION_REGION="" DEVELOPMENT_TEAM="GQSBJKL2HP" RUN_TARGET_PROJECT_NAME="iosApp" RUN_TARGET_NAME="iosApp" MAKE_ACTIVE="TRUE" SHOULD_DEBUG_EXTENSIONS="false">
       <embedded_app_extension_list />
       <method v="2">
         <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
@@ -716,13 +571,6 @@
     <MESSAGE value="Release v4.0.0&#10;&#10;- Added GentleSquircleShape.kt&#10;- Added GentleSquircleBasedShape.kt&#10;- Added GentleSquircleShapePath.kt&#10;- Fixed corner smoothing to radius scaling.&#10;- Fixed RTL/LTR mirroring." />
     <MESSAGE value="Refactor: Improve shape drawing and update dependencies.&#10;&#10;This commit introduces several key changes:&#10;&#10;-   **Refactored `SquircleShapePath`:**&#10;    -   Removed the corner radius scaling that was dependent on the smoothing value.&#10;    -   Replaced straight `lineTo` calls with `cubicTo` for the shape's edges, allowing for a subtle pinch effect and a more organic appearance.&#10;&#10;-   **Updated Dependencies:**&#10;    -   Bumped Kotlin to `2.3.0` and Compose to `1.11.0`.&#10;    -   Migrated project dependencies to use the version catalog (`libs.versions.toml`).&#10;    -   Updated the library version to `5.0.0` and changed the `groupId`.&#10;&#10;-   **Sample App Improvements:**&#10;    -   Refactored the preview screen to use a `ViewModel` for state management.&#10;    -   Introduced Koin for dependency injection.&#10;    -   Improved layout responsiveness for larger screens.&#10;&#10;-   **Documentation:**&#10;    -   Updated `README.md` with breaking changes for version `5.0.0`, new minimum requirements, and updated dependency instructions." />
     <option name="LAST_COMMIT_MESSAGE" value="Refactor: Improve shape drawing and update dependencies.&#10;&#10;This commit introduces several key changes:&#10;&#10;-   **Refactored `SquircleShapePath`:**&#10;    -   Removed the corner radius scaling that was dependent on the smoothing value.&#10;    -   Replaced straight `lineTo` calls with `cubicTo` for the shape's edges, allowing for a subtle pinch effect and a more organic appearance.&#10;&#10;-   **Updated Dependencies:**&#10;    -   Bumped Kotlin to `2.3.0` and Compose to `1.11.0`.&#10;    -   Migrated project dependencies to use the version catalog (`libs.versions.toml`).&#10;    -   Updated the library version to `5.0.0` and changed the `groupId`.&#10;&#10;-   **Sample App Improvements:**&#10;    -   Refactored the preview screen to use a `ViewModel` for state management.&#10;    -   Introduced Koin for dependency injection.&#10;    -   Improved layout responsiveness for larger screens.&#10;&#10;-   **Documentation:**&#10;    -   Updated `README.md` with breaking changes for version `5.0.0`, new minimum requirements, and updated dependency instructions." />
-  </component>
-  <component name="XcodeBuildConfigurationMetadata">
-    <buildConfigurationMetadataMap>
-      <entry key="Xcode Application.iosApp">
-        <BuildConfigurationMetadata buildDestinationId="iphonesimulator_C2A60FCC-C161-41C5-A71A-28CB1BA91477" wasRun="true" />
-      </entry>
-    </buildConfigurationMetadataMap>
   </component>
   <component name="play_dynamic_filters_status">
     <option name="appIdToCheckInfo">

--- a/README.md
+++ b/README.md
@@ -2,56 +2,92 @@
 
 ![Maven Central Version](https://img.shields.io/maven-central/v/com.stoyanvuchev/squircle-shape)
 [![API](https://img.shields.io/badge/API-23%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=23)
-[![Last Commit](https://img.shields.io/github/last-commit/stoyan-vuchev/squircle-shape.svg?style=flat&logo=github&logoColor=white)](https://github.com/stoyan-vuchev/squircle-shape/commits/master)
+[![Last Commit](https://img.shields.io/github/last-commit/stoyan-vuchev/squircle-shape/stable.svg?style=flat&logo=github&logoColor=white)](https://github.com/stoyan-vuchev/squircle-shape/commits/stable)
 [![Issues](https://img.shields.io/github/issues-raw/stoyan-vuchev/squircle-shape.svg?style=flat&logo=github&logoColor=white)](https://github.com/stoyan-vuchev/squircle-shape/issues)
-[![As Seen In](https://img.shields.io/badge/As_Seen_In-jetc.dev_Newsletter_Issue_%23168-blue?logo=Jetpack+Compose&amp;logoColor=white)](https://jetc.dev/issues/168.html)
+[![As Seen In](https://img.shields.io/badge/As_Seen_In-jetc.dev_Newsletter_Issue_%23168-blue?logo=Jetpack+Compose&logoColor=white)](https://jetc.dev/issues/168.html)
 
-> A Compose Multiplatform library providing customizable Squircle shapes for UI components.
+> A Compose Multiplatform library providing customizable **Squircle** shapes for modern UI components.
+
+---
+
+## 🌿 Release Channels
+
+This project maintains two long-lived branches:
+
+### 🟢 [`stable`](https://github.com/stoyan-vuchev/squircle-shape/tree/stable)
+- Built with the latest **stable** Compose Multiplatform / Jetpack Compose versions.
+- Recommended for **production apps**.
+- Published versions follow semantic versioning (e.g. `5.1.1`).
+
+### 🧪 [`experimental`](https://github.com/stoyan-vuchev/squircle-shape/tree/experimental)
+- Built with **alpha / beta / RC** Compose versions.
+- May introduce breaking changes earlier.
+- Intended for early adopters and testing upcoming Compose updates.
+
+If you're building a production app, use the latest stable release from Maven Central.
 
 ---
 
 ## ✨ Features
 
-- **Customizable Squircle Shapes**: Create UI shapes that smoothly transition between squares and circles.
-- **Integration with `MaterialTheme`**: Use squircle shapes directly in Jetpack Compose themes.
-- **Corner Smoothing**: Fine-tune the smoothness of corners for a delightful design.
-- **Multiplatform Support**: Available for Android, iOS, Desktop (JVM), and Web (WasmJS).
-- **Canvas Drawing**: Easily draw squircle shapes on canvases with `drawSquircle()`.
+- **Customizable Squircle Shapes** — Smooth transition between squares and circles.
+- **MaterialTheme Integration** — Use directly inside `MaterialTheme.shapes`.
+- **Corner Smoothing Control** — Fine-tune curvature for precise design language.
+- **Compose Multiplatform Support** — Android, iOS, Desktop (JVM), Web (WasmJS).
+- **Canvas Support** — Draw squircles using `drawSquircle()`.
 
 ---
 
-## ⚠️‼️📢 Important Notice
+## ⚠️ Important Notice
 
-- **The library namespace has changed**:
-  </br>
-  New library versions will be published using the `com.stoyanvuchev` namespace.
-  </br>
-  Consider replacing `io.github.stoyan-vuchev` with `com.stoyanvuchev`.
-  <br/>
-  Check out the updated Setup guide [here](#-setup)
+### Namespace Change
+
+The library is now published under the `com.stoyanvuchev` namespace.
+
+If upgrading from older versions, replace: `io.github.stoyan-vuchev` with `com.stoyanvuchev`
+
+Check out the updated Setup guide [here](#-setup)
 
 ---
 
-## 🆕 What's New in Version 5.1.0?
+## 🆕 What's New
 
-**‼️ Breaking Changes**:  
-- Starting with this release, the library is now configured to use AGP version 9+. Conflicts are highly possible for projects configured with older AGP versions. Check [this](https://kotlinlang.org/docs/multiplatform/multiplatform-project-agp-9-migration.html) link for more information.
+See full release history here:  
+https://github.com/stoyan-vuchev/squircle-shape/releases
 
 ---
 
 ## 📋 Minimum Requirements
 
-### For Multiplatform Projects:
-- AGP: `9.0.0`
-- Kotlin: `2.3.0`
-- CMP: `1.11.0-alpha02`
+### 🟢 Stable Branch
 
-### For Android-only Projects:
-- AGP: `9.0.0`
-- Kotlin: `2.3.0`
-- Jetpack Compose: `1.11.0-alpha04`
+#### Multiplatform:
+- AGP: `9.0.0+`
+- Kotlin: `2.3.0+`
+- Compose Multiplatform: `1.10.1+`
+
+#### Android-only:
+- AGP: `9.0.0+`
+- Kotlin: `2.3.0+`
+- Jetpack Compose: `1.10.3+`
 - Minimum SDK: `23`
 - Compile SDK: `36`
+
+### 🧪 Experimental Branch
+
+#### Multiplatform:
+- AGP: `9.0.0+`
+- Kotlin: `2.3.0+`
+- Compose Multiplatform: `1.11.0-alpha02+`
+
+#### Android-only:
+- AGP: `9.0.0+`
+- Kotlin: `2.3.0+`
+- Jetpack Compose: `1.11.0-alpha04+`
+- Minimum SDK: `23`
+- Compile SDK: `36`
+
+---
 
 ---
 
@@ -71,7 +107,7 @@ sourceSets {
             
             // ...
             
-            implementation("com.stoyanvuchev:squircle-shape:5.1.0")
+            implementation("com.stoyanvuchev:squircle-shape:5.1.1")
           
         }
       
@@ -86,7 +122,7 @@ sourceSets {
 
 ```toml
 [versions]
-squircle-shape = "5.1.0"
+squircle-shape = "5.1.1"
 
 [libraries]
 squircle-shape = { group = "com.stoyanvuchev", name = "squircle-shape", version.ref = "squircle-shape" }
@@ -128,7 +164,7 @@ dependencies {
             
     // ...
 
-    implementation("com.stoyanvuchev:squircle-shape-android:5.1.0")
+    implementation("com.stoyanvuchev:squircle-shape-android:5.1.1")
   
 }
 ```
@@ -137,7 +173,7 @@ dependencies {
 
 ```toml
 [versions]
-squircle-shape = "5.1.0"
+squircle-shape = "5.1.1"
 
 [libraries]
 squircle-shape = { group = "com.stoyanvuchev", name = "squircle-shape-android", version.ref = "squircle-shape" }
@@ -300,7 +336,7 @@ Canvas(
 ```
 MIT License
 
-Copyright (c) 2023-2025 Stoyan Vuchev
+Copyright (c) 2023-2026 Stoyan Vuchev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,55 +1,56 @@
 [versions]
 
 # Plugins
-composePlugin = "1.11.0-alpha02"
-composeAndroid = "1.11.0-alpha04"
+composePlugin = "1.10.1"
+composeAndroid = "1.10.3"
 agp = "9.0.0"
 kotlin = "2.3.0"
 vanniktechMavenPublish = "0.36.0"
 
 # Core Dependencies
-core-ktx = "1.17.0"
+coreKtx = "1.17.0"
 lifecycle = "2.9.6"
 
 # Compose Dependencies
-activity-compose = "1.12.3"
-navigation-compose = "2.9.1"
+activityCompose = "1.12.4"
+navigationCompose = "2.9.2"
+material3ComposeAndroid = "1.4.0"
+material3ComposeMultiplatform = "1.10.0-alpha05"
 
 # Other
 systemUiBarsTweaker = "1.3.0"
-kotlinx-coroutines = "1.10.2"
+kotlinxCoroutines = "1.10.2"
 koin = "4.1.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 appcompat = "1.7.1"
 material = "1.13.0"
-material3Compose = "1.4.0"
 
 # =================================================================================================
 
 [libraries]
 
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composePlugin" }
 foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composePlugin" }
 lifecycle-runtime-ktx = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
-androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composePlugin" }
-material3-windowsizeclass = { module = "org.jetbrains.compose.material3:material3-window-size-class", version.ref = "composePlugin" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3ComposeMultiplatform" }
+material3-windowsizeclass = { module = "org.jetbrains.compose.material3:material3-window-size-class", version.ref = "material3ComposeMultiplatform" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composePlugin" }
 systemUiBarsTweaker = { group = "com.github.stoyan-vuchev", name = "system-ui-bars-tweaker", version.ref = "systemUiBarsTweaker" }
-kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinxCoroutines" }
 ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composePlugin" }
 ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composePlugin" }
 ui-util = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "composePlugin" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "composeAndroid" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "composeAndroid" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "composeAndroid" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3Compose" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3ComposeAndroid" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -65,7 +65,7 @@ mavenPublishing {
     coordinates(
         groupId = "com.stoyanvuchev",
         artifactId = "squircle-shape",
-        version = "5.1.0"
+        version = "5.1.1"
     )
 
     pom {


### PR DESCRIPTION
This commit introduces several documentation and dependency updates:

-   **README Improvements:**
    -   Updated the library version to `5.1.1`.
    -   Introduced documentation for `stable` and `experimental` release channels.
    -   Updated minimum requirements for both Stable (Compose `1.10.1+`) and Experimental (Compose `1.11.0-alpha02+`) branches.
    -   Updated the copyright year to 2026.
    -   Refined the features list and namespace change instructions.

-   **Updated Dependencies (`libs.versions.toml`):**
    -   Reverted `composePlugin` to `1.10.1` and `composeAndroid` to `1.10.3` to match the stable branch requirements.
    -   Updated `activityCompose` to `1.12.4` and `navigationCompose` to `2.9.2`.
    -   Introduced explicit versions for `material3ComposeAndroid` (`1.4.0`) and `material3ComposeMultiplatform` (`1.10.0-alpha05`).
    -   Standardized naming conventions for several version keys (e.g., `coreKtx`, `kotlinxCoroutines`).

-   **Library Configuration:**
    -   Updated the library version in `library/build.gradle.kts` to `5.1.1`.