### PR TITLE
Update: Bump library version to 5.2.0 and upgrade Gradle Wrapper.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Aug 10 21:49:08 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -65,7 +65,7 @@ mavenPublishing {
     coordinates(
         groupId = "com.stoyanvuchev",
         artifactId = "squircle-shape",
-        version = "5.1.1"
+        version = "5.2.0"
     )
 
     pom {


### PR DESCRIPTION
This commit updates the project versioning and core build infrastructure.

- **Library Configuration:**
    - Updated the library version from `5.1.1` to `5.2.0` in `library/build.gradle.kts`.

- **Gradle Build System:**
    - Upgraded the Gradle Wrapper distribution version from `9.3.1` to `9.4.0`.